### PR TITLE
Move to ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ to bootstrap a pentest virtual machine
 * vagrant
 * ansible
 * virtualbox
-* (optional) virtualbox extension
+* virtualbox-guest-additions-iso (for guest OS installation)
+* (optional) virtualbox extension. Menu available under File > Preferences > Extensions.
 
 # Getting started
 
@@ -23,3 +24,28 @@ vagrant up
 ```
 
 To login: vagrant / vagrant
+
+# Running ansible playbooks manually
+
+Depending on the ansible provider, you can run playbooks manually for troubleshooting them
+
+## ansible_local
+
+Connect to your instance with `vagrant ssh` and execute the following
+```bash
+ansible -i localhost -m ping
+ansible-playbook -i localhost, -c local /vagrant/res/ansible/main.yml --tags some_tags
+```
+
+## ansible
+
+You need ansible to be installed on the host to do that.
+```bash
+python3 -m pip install ansible
+```
+
+You can run the playbook with
+```bash
+export ANSIBLE_HOST_KEY_CHECKING=False
+ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory res/ansible/pb-dummy.yml
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Vagrant pentest
+# Vagrant sandbox
 
 This repository hosts the vagrantfile and relevant resoures 
-to bootstrap a pentest virtual machine
+to bootstrap a sandbox virtual machine
 
 # Requirements
 
@@ -18,7 +18,7 @@ Update submodules
 make update-submodule
 ```
 
-Deploy vagrant pentest
+Deploy vagrant sandbox
 ```bash
 vagrant up
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,6 +66,9 @@ Vagrant.configure("2") do |config|
                     vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
                 end
 
+                # enables copy/paste with host and vm
+                vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+
                 # Setups audio
                 if target["reqAudio"]
                     vb.customize [

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ Vagrant.configure("2") do |config|
                     ansible.playbook = playbook["path"]
                     # ansible_local does not support vault pass.
                     if playbook["supplier"] != "ansible_local"
-                      ansible.ask_vault_pass = target["ask_vault_pass"]
+                      ansible.ask_vault_pass = playbook["ask_vault_pass"]
                     end
                 end
             end

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -12,7 +12,10 @@
       gui: true
       reqAudio: false
       ask_vault_pass  : false
-      ansible_supplier: ansible_local
       playbooks:
-        - res/ansible/main.yml
+        # this requires ansible on the host.
+        - path: res/ansible/vboxguest.yml
+          supplier: ansible
+        - path: res/ansible/main.yml
+          supplier: ansible_local
 ...

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,5 +1,5 @@
 targets:
-  sandbox-01:
+  sandbox-02:
     box: ubuntu/jammy64
     version: 20230510.0.0
     # other ranges could fail?

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,21 +1,19 @@
----
-  targets:
-    pentest-test:
-      box: ubuntu/jammy64
-      version: 20230510.0.0
-      # other ranges could fail? 
-      # see: https://github.com/hashicorp/vagrant/issues/12557
-      ip: 192.168.56.105
-      cpus: 2 
-      memory: 2048
-      vram: 32
-      gui: true
-      reqAudio: false
-      ask_vault_pass  : false
-      playbooks:
-        # this requires ansible on the host.
-        - path: res/ansible/vboxguest.yml
-          supplier: ansible
-        - path: res/ansible/main.yml
-          supplier: ansible_local
-...
+targets:
+  pentest-test:
+    box: ubuntu/jammy64
+    version: 20230510.0.0
+    # other ranges could fail?
+    # see: https://github.com/hashicorp/vagrant/issues/12557
+    ip: 192.168.56.105
+    cpus: 3
+    memory: 4096
+    vram: 32
+    gui: true
+    reqAudio: false
+    playbooks:
+      # this requires ansible on the host.
+      - path: res/ansible/vboxguest.yml
+        supplier: ansible
+        ask_vault_pass: false
+      - path: res/ansible/main.yml
+        supplier: ansible_local

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -11,9 +11,13 @@ targets:
     gui: true
     reqAudio: false
     playbooks:
-      # this requires ansible on the host.
+      # we need to run this with ansible from the host to push the
+      # guest additions.
       - path: res/ansible/vboxguest.yml
         supplier: ansible
         ask_vault_pass: false
       - path: res/ansible/main.yml
         supplier: ansible_local
+      - path: res/ansible/reboot.yml
+        supplier: ansible
+        ask_vault_pass: false

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,5 +1,5 @@
 targets:
-  pentest-test:
+  sandbox-01:
     box: ubuntu/jammy64
     version: 20230510.0.0
     # other ranges could fail?

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,13 +1,13 @@
 ---
   targets:
-    pentest:
-      box: kalilinux/rolling 
-      version: 2023.1.0
+    pentest-test:
+      box: ubuntu/jammy64
+      version: 20230510.0.0
       # other ranges could fail? 
       # see: https://github.com/hashicorp/vagrant/issues/12557
       ip: 192.168.56.105
-      cpus: 3
-      memory: 4096
+      cpus: 2 
+      memory: 2048
       vram: 32
       gui: true
       reqAudio: false

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,5 +1,5 @@
 targets:
-  sandbox-02:
+  sandbox-01:
     box: ubuntu/jammy64
     version: 20230510.0.0
     # other ranges could fail?

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -4,9 +4,6 @@
   become: yes
   tasks:
 
-  # This allows you to define os specific variables
-  # Facts can be collected using the following command
-  # ansible -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory all -m setup -a 'gather_subset=!all' 
   - name: Gather os specific variables
     include_vars: "{{ item }}" 
     with_first_found:
@@ -14,6 +11,14 @@
     - "vars/{{ ansible_distribution_version | lower }}.yml"
     tags: 
       - set-vars
+
+  - include_role:
+      name: ansible-role-virtualbox-guest
+      apply:
+        tags: 
+          - install-vboxguest
+    tags:
+      - install-vboxguest
 
   - name: Update all packages to the latest version
     apt:
@@ -57,10 +62,74 @@
     tags:
       - install-base-packages
 
+  ## Nord VPN
+  #########################################
   - name: Install NordVPN
-    ansible.builtin.shell: "wget -qO - https://downloads.nordcdn.com/apps/linux/install.sh | sh -s -- -n"
+    ansible.builtin.shell: "wget -qO - https://downloads.nordcdn.com/apps/linux/install.sh | sh -"
     tags:
       - install-nordvpn
+
+  ## Burp community
+  #########################################
+  - name: Download Burp Suite
+    ansible.builtin.get_url:
+      url: https://portswigger.net/burp/releases/download?product=community&type=linux
+      dest: /tmp/burpcommunity.sh
+      mode: '0755'
+    tags: install-burp
+
+  - name: Install Burp
+    # this is to deal with burpcommunity prompt installtion
+    #   This will install Burp Suite Community Edition on your computer.
+    #   OK [o, Enter], Cancel [c]
+    #   Where should Burp Suite Community Edition be installed?
+    #   [/home/vagrant/BurpSuiteCommunity]
+    #   Create symlinks?
+    #   Yes [y, Enter], No [n]
+    #   Select the folder where you would like Burp Suite Community Edition to create symlinks, then click Next.
+    #   [/usr/local/bin]
+    #   Extracting files ...
+    #   ...
+    ansible.builtin.shell: |
+      /tmp/burpcommunity.sh << EOF
+      o
+      /opt/BurpSuiteCommunity
+      y
+      /usr/local/bin
+      EOF
+    tags: install-burp
+
+  ## OleVBA
+  #########################################
+  - name: Install Olevba tools
+    ansible.builtin.shell: python3 -m pip install --upgrade pip oletools
+    tags: install-oletools
+
+  ## pdfid, pdf-parser (DidierStensSuite)
+  #########################################
+  - name: Clone DidierStevensSuite from GitHub
+    git:
+      repo: 'https://github.com/DidierStevens/DidierStevensSuite.git'
+      dest: '/opt/DidierStevensSuite'
+      force: yes
+    tags: install-pdftools
+
+  - name: Make scripts executable
+    file:
+      path: "/opt/DidierStevensSuite/{{ item }}"
+      mode: '0755'
+    loop:
+      - pdf-parser.py
+      - pdfid.py
+    tags: install-pdftools
+
+  - name: Add DidierStevensSuite to PATH in .bashrc
+    lineinfile:
+      path: '/home/vagrant/.bashrc'
+      line: 'export PATH=$PATH:/opt/DidierStevensSuite'
+      state: present
+    become_user: vagrant
+    tags: install-pdftools
 
   # since we now use the ansible_local provider, we canot use the reboot
   # module to reboot the host. The following error is thrown:

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -150,6 +150,28 @@
     become_user: vagrant
     tags: install-pdftools
 
+  ## Tesseract
+  #########################################
+  - name: Tesseract - Installation
+    ansible.builtin.apt:
+      name:
+        - tesseract-ocr
+      state: present
+      update_cache: yes
+    tags: install-tesseract
+
+  - name: Tesseract - install fra package
+    ansible.builtin.get_url:
+      url: https://github.com/tesseract-ocr/tessdata/raw/4.00/fra.traineddata
+      dest: /usr/share/tesseract-ocr/4.00/tessdata/
+    tags: install-tesseract
+
+  - name: Tesseract - install eng package
+    ansible.builtin.get_url:
+      url: https://github.com/tesseract-ocr/tessdata/raw/4.00/eng.traineddata
+      dest: /usr/share/tesseract-ocr/4.00/tessdata/
+    tags: install-tesseract
+
   ## Ghidra
   #########################################
   - name: Ghidra - Install requirements

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -1,4 +1,3 @@
----
 - hosts: all
   gather_facts: yes
   become: yes
@@ -12,14 +11,6 @@
     tags: 
       - set-vars
 
-  - include_role:
-      name: ansible-role-virtualbox-guest
-      apply:
-        tags: 
-          - install-vboxguest
-    tags:
-      - install-vboxguest
-
   - name: Update all packages to the latest version
     apt:
       state: latest
@@ -27,6 +18,24 @@
     tags:
       - install-update
 
+  - name: Install base packages
+    ansible.builtin.apt:
+      pkg: 
+        "{{ packages }}"
+      state: latest
+      update_cache: yes
+    tags:
+      - install-base-packages
+
+  - name: Change vagrant shell
+    user:
+      name: vagrant
+      shell: /bin/zsh
+    tags:
+      - config-shell
+
+  ## docker
+  #########################################
   - name: Install docker
     ansible.builtin.apt:
       pkg:
@@ -52,15 +61,6 @@
     become: yes
     tags:
       - install-docker
-
-  - name: Install base packages
-    ansible.builtin.apt:
-      pkg: 
-        "{{ packages }}"
-      state: latest
-      update_cache: yes
-    tags:
-      - install-base-packages
 
   ## Nord VPN
   #########################################
@@ -107,14 +107,14 @@
 
   ## pdfid, pdf-parser (DidierStensSuite)
   #########################################
-  - name: Clone DidierStevensSuite from GitHub
+  - name: Cloning pdf github tools
     git:
       repo: 'https://github.com/DidierStevens/DidierStevensSuite.git'
       dest: '/opt/DidierStevensSuite'
       force: yes
     tags: install-pdftools
 
-  - name: Make scripts executable
+  - name: Adding execution permission to the pdf tools
     file:
       path: "/opt/DidierStevensSuite/{{ item }}"
       mode: '0755'
@@ -123,9 +123,9 @@
       - pdfid.py
     tags: install-pdftools
 
-  - name: Add DidierStevensSuite to PATH in .bashrc
+  - name: Adding pdftools to shell profile
     lineinfile:
-      path: '/home/vagrant/.bashrc'
+      path: '/home/vagrant/.zshrc'
       line: 'export PATH=$PATH:/opt/DidierStevensSuite'
       state: present
     become_user: vagrant

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -27,13 +27,6 @@
     tags:
       - install-base-packages
 
-  - name: Change vagrant shell
-    user:
-      name: vagrant
-      shell: /bin/zsh
-    tags:
-      - config-shell
-
   ## docker
   #########################################
   - name: Install docker
@@ -125,7 +118,7 @@
 
   - name: Adding pdftools to shell profile
     lineinfile:
-      path: '/home/vagrant/.zshrc'
+      path: '/home/vagrant/.bashrc'
       line: 'export PATH=$PATH:/opt/DidierStevensSuite'
       state: present
     become_user: vagrant

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -29,7 +29,7 @@
 
   ## docker
   #########################################
-  - name: Install docker
+  - name: Docker - Installation
     ansible.builtin.apt:
       pkg:
         - docker.io
@@ -38,7 +38,7 @@
     tags:
       - install-docker
 
-  - name: Enable docker on systemd
+  - name: Docker - Enable docker on systemd
     ansible.builtin.systemd:
       name: docker
       enabled: yes
@@ -46,7 +46,7 @@
     tags:
       - install-docker
 
-  - name: Add vagrant to docker group
+  - name: Docker - Add vagrant to docker group
     user:
       name: vagrant
       groups: docker
@@ -57,21 +57,22 @@
 
   ## Nord VPN
   #########################################
-  - name: Install NordVPN
+  - name: NordVPN - Installation
     ansible.builtin.shell: "wget -qO - https://downloads.nordcdn.com/apps/linux/install.sh | sh -"
     tags:
       - install-nordvpn
 
   ## Burp community
   #########################################
-  - name: Download Burp Suite
+  - name: Burp - Download
     ansible.builtin.get_url:
       url: https://portswigger.net/burp/releases/download?product=community&type=linux
+      # other URL: https://portswigger.net/burp/releases/download?product=community&version=2023.5.1&type=linux
       dest: /tmp/burpcommunity.sh
       mode: '0755'
     tags: install-burp
 
-  - name: Install Burp
+  - name: Burp - Installation
     # this is to deal with burpcommunity prompt installtion
     #   This will install Burp Suite Community Edition on your computer.
     #   OK [o, Enter], Cancel [c]
@@ -94,21 +95,30 @@
 
   ## OleVBA
   #########################################
-  - name: Install Olevba tools
+  - name: Olevba - Install requirements
+    ansible.builtin.apt:
+      name:
+        - python3
+        - python3-pip
+      state: present
+      update_cache: yes
+    tags: install-oletools
+
+  - name: Olevba - Installation
     ansible.builtin.shell: python3 -m pip install --upgrade pip oletools
     tags: install-oletools
 
   ## pdfid, pdf-parser (DidierStensSuite)
   #########################################
-  - name: Cloning pdf github tools
-    git:
+  - name: Pdftools - Cloning pdf github tools
+    ansible.builtin.git:
       repo: 'https://github.com/DidierStevens/DidierStevensSuite.git'
       dest: '/opt/DidierStevensSuite'
       force: yes
     tags: install-pdftools
 
-  - name: Adding execution permission to the pdf tools
-    file:
+  - name: Pdftools - Adding execution permission to the pdf tools
+    ansible.builtin.file:
       path: "/opt/DidierStevensSuite/{{ item }}"
       mode: '0755'
     loop:
@@ -116,13 +126,78 @@
       - pdfid.py
     tags: install-pdftools
 
-  - name: Adding pdftools to shell profile
-    lineinfile:
+  - name: Pdftools - Adding pdftools to shell profile
+    ansible.builtin.lineinfile:
       path: '/home/vagrant/.bashrc'
       line: 'export PATH=$PATH:/opt/DidierStevensSuite'
       state: present
     become_user: vagrant
     tags: install-pdftools
+
+  ## Ghidra
+  #########################################
+  - name: Ghidra - Install requirements
+    ansible.builtin.apt:
+      name:
+        - openjdk-17-jdk
+        - wget
+        - unzip
+      state: present
+      update_cache: yes
+    tags: install-ghidra
+
+  - name: Ghidra - Set the PATH environment for JAVA
+    ansible.builtin.lineinfile:
+      path: '/home/vagrant/.bashrc'
+      line: 'export PATH=$PATH:/usr/lib/jvm/java-17-openjdk-amd64/bin/'
+      state: present
+    tags: install-ghidra
+
+  - name: Ghidra - Download
+    ansible.builtin.get_url:
+      url: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.3_build/ghidra_10.3_PUBLIC_20230510.zip
+      dest: /tmp/ghidra.zip
+    tags: install-ghidra
+
+  - name: Ghidra - Unzip
+    ansible.builtin.unarchive:
+      src: /tmp/ghidra.zip
+      dest: /opt/
+      creates: /opt/ghidra
+    tags: install-ghidra
+
+  - name: Ghidra - Rename Ghidra directory
+    ansible.builtin.shell:
+      cmd: mv /opt/ghidra_* /opt/ghidra
+      creates: /opt/ghidra
+    tags: install-ghidra
+
+  - name: Ghidra - Set the PATH environment variable
+    ansible.builtin.lineinfile:
+      path: '/home/vagrant/.bashrc'
+      line: 'export PATH=$PATH:/opt/ghidra'
+      state: present
+    tags: install-ghidra
+
+  ## Brave
+  #########################################
+  - name: Brave - Import repository key
+    ansible.builtin.apt_key:
+      url: https://brave-browser-apt-release.s3.brave.com/brave-core.asc
+      state: present
+    tags: install-brave
+
+  - name: Brave - Add the Brave Browser repository
+    ansible.builtin.apt_repository:
+      repo: "deb [arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main"
+      state: present
+    tags: install-brave
+
+  - name: Brave - Install Brave Browser
+    ansible.builtin.apt:
+      name: brave-browser
+      state: present
+      updat_cache: yes
 
   # since we now use the ansible_local provider, we canot use the reboot
   # module to reboot the host. The following error is thrown:

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -197,7 +197,7 @@
     ansible.builtin.apt:
       name: brave-browser
       state: present
-      updat_cache: yes
+      update_cache: yes
 
   # since we now use the ansible_local provider, we canot use the reboot
   # module to reboot the host. The following error is thrown:

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -84,13 +84,15 @@
     #   [/usr/local/bin]
     #   Extracting files ...
     #   ...
-    ansible.builtin.shell: |
-      /tmp/burpcommunity.sh << EOF
-      o
-      /opt/BurpSuiteCommunity
-      y
-      /usr/local/bin
-      EOF
+    ansible.builtin.shell:
+      cmd: |-
+        /tmp/burpcommunity.sh << EOF
+        o
+        /opt/BurpSuiteCommunity
+        y
+        /usr/local/bin
+        EOF
+      creates: /opt/BurpSuiteCommunity
     tags: install-burp
 
   ## OleVBA
@@ -110,11 +112,25 @@
 
   ## pdfid, pdf-parser (DidierStensSuite)
   #########################################
+  - name: Pdftools - Install pdf-to-text
+    ansible.builtin.apt:
+      name:
+        - poppler-utils
+      state: present
+      update_cache: yes
+    tags: install-pdftools
+
   - name: Pdftools - Cloning pdf github tools
     ansible.builtin.git:
       repo: 'https://github.com/DidierStevens/DidierStevensSuite.git'
       dest: '/opt/DidierStevensSuite'
       force: yes
+    tags: install-pdftools
+
+  - name: Pdftools - Set python alternatives
+    ansible.builtin.command:
+      cmd: update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+      creates: /etc/alternatives/python
     tags: install-pdftools
 
   - name: Pdftools - Adding execution permission to the pdf tools
@@ -177,6 +193,23 @@
       path: '/home/vagrant/.bashrc'
       line: 'export PATH=$PATH:/opt/ghidra'
       state: present
+    tags: install-ghidra
+
+  - name: Ghidra - Create a .desktop shortcut for My Program
+    copy:
+      dest: /usr/share/applications/ghidra.desktop
+      owner: root
+      group: root
+      mode: '0755'
+      content: |
+        [Desktop Entry]
+        Type=Application
+        Name=Ghidra
+        Comment=Reverse engineer application
+        Icon=/opt/ghidra/docs/GhidraClass/Intermediate/Images/GhidraLogo64.png
+        Exec=/opt/ghidra/ghidraRun
+        Terminal=false
+        Categories=Utility;Application;
     tags: install-ghidra
 
   ## Brave

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -55,6 +55,45 @@
     tags:
       - install-docker
 
+  ## oh-my-zsh
+  #########################################
+  - name: Install Oh My Zsh
+    shell: sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+    args:
+      executable: /bin/bash
+      creates: /home/vagrant/.oh-my-zsh/
+    become_user: "vagrant"
+    changed_when: false
+    tags:
+      - install-ohmyzsh
+
+  - name: Install zsh-autosuggestions plugin
+    git:
+      repo: https://github.com/zsh-users/zsh-autosuggestions
+      dest: "/home/vagrant/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+      force: yes
+    become_user: "vagrant"
+    tags:
+      - install-ohmyzsh
+
+  - name: Enable zsh-autosuggestions plugin
+    lineinfile:
+      path: "/home/vagrant/.zshrc"
+      backrefs: yes
+      regexp: '^plugins=\((.*)\)'
+      line: 'plugins=(\1 zsh-autosuggestions)'
+    become_user: "vagrant"
+    when: lookup('file', "/home/vagrant/.zshrc") is not search('zsh-autosuggestions')
+    tags:
+      - install-ohmyzsh
+
+  - name: Set zsh as default shell
+    user:
+      name: "vagrant"
+      shell: /bin/zsh
+    tags:
+      - install-ohmyzsh
+
   ## Nord VPN
   #########################################
   - name: NordVPN - Installation
@@ -144,7 +183,7 @@
 
   - name: Pdftools - Adding pdftools to shell profile
     ansible.builtin.lineinfile:
-      path: '/home/vagrant/.bashrc'
+      path: '/home/vagrant/.zshrc'
       line: 'export PATH=$PATH:/opt/DidierStevensSuite'
       state: present
     become_user: vagrant
@@ -186,7 +225,7 @@
 
   - name: Ghidra - Set the PATH environment for JAVA
     ansible.builtin.lineinfile:
-      path: '/home/vagrant/.bashrc'
+      path: '/home/vagrant/.zshrc'
       line: 'export PATH=$PATH:/usr/lib/jvm/java-17-openjdk-amd64/bin/'
       state: present
     tags: install-ghidra
@@ -212,7 +251,7 @@
 
   - name: Ghidra - Set the PATH environment variable
     ansible.builtin.lineinfile:
-      path: '/home/vagrant/.bashrc'
+      path: '/home/vagrant/.zshrc'
       line: 'export PATH=$PATH:/opt/ghidra'
       state: present
     tags: install-ghidra
@@ -253,10 +292,3 @@
       name: brave-browser
       state: present
       update_cache: yes
-
-  # since we now use the ansible_local provider, we canot use the reboot
-  # module to reboot the host. The following error is thrown:
-  # fatal: [pentest]: FAILED! => {"changed": false, "elapsed": 0, "msg": "Running reboot with local connection would reboot the control node.", "rebooted": false}
-  - ansible.builtin.debug: msg="Reboot host MANUALLY to apply updates"
-    tags:
-      - reboot

--- a/res/ansible/reboot.yml
+++ b/res/ansible/reboot.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: yes
+  become: yes
+  tasks:
+
+  - name: Rebooting
+    ansible.builtin.reboot:
+      reboot_timeout: 300

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -1,5 +1,9 @@
 packages:
-  - ubuntu-desktop
+  # GUI
+  - lightdm
+  - xfce4
+  #- ubuntu-desktop # this is for gnome4
+  # base tools
   - zsh
   - terminator
   - kmod

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -1,8 +1,7 @@
 packages:
   # GUI
-  - lightdm
-  - xfce4
   #- ubuntu-desktop # this is for gnome4
+  - cinnamon-desktop-environment
   # base tools
   - zsh
   - terminator

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -1,7 +1,7 @@
 packages:
   # GUI
-  #- ubuntu-desktop # this is for gnome4
-  - cinnamon-desktop-environment
+  - ubuntu-desktop # this is for gnome4
+  - cinnamon # this is for gnome4
   # base tools
   - zsh
   - terminator

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -1,0 +1,9 @@
+packages:
+  - ubuntu-desktop
+  - zsh
+  - terminator
+  - kmod
+  - unzip
+  - git
+  - python3
+  - python3-pip

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -9,5 +9,5 @@ packages:
   - kmod
   - unzip
   - git
-  - python3
-  - python3-pip
+  - firefox
+  - chromium-browser

--- a/res/ansible/vboxguest.yml
+++ b/res/ansible/vboxguest.yml
@@ -1,0 +1,11 @@
+- hosts: all
+  gather_facts: yes
+  become: yes
+  tasks:
+  - include_role:
+      name: ansible-role-virtualbox-guest
+      apply:
+        tags: 
+          - install-vboxguest
+    tags:
+      - install-vboxguest

--- a/res/ansible/vboxguest.yml
+++ b/res/ansible/vboxguest.yml
@@ -2,6 +2,7 @@
   gather_facts: yes
   become: yes
   tasks:
+
   - include_role:
       name: ansible-role-virtualbox-guest
       apply:
@@ -9,3 +10,7 @@
           - install-vboxguest
     tags:
       - install-vboxguest
+
+  - name: Rebooting
+    ansible.builtin.reboot:
+      reboot_timeout: 300


### PR DESCRIPTION
# Summary

This PR moves the image to Ubuntu instead of Kali.
Even though Kali comes with many tools, it is sometimes hard to install new tools on it due to the dependencies already there (exemple with malcat).

Using a fresh and popular distrib is easier for these scenarios