### PR TITLE
Upgrade playbook to 24.04 and Fix for Apple M4 and java

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Depending on the ansible provider, you can run playbooks manually for troublesho
 Connect to your instance with `vagrant ssh` and execute the following
 ```bash
 ansible -i localhost -m ping
-ansible-playbook -i localhost, -c local /vagrant/res/ansible/main.yml --tags some_tags
+ansible-playbook -i localhost, -c local /path/to/share/res/ansible/main.yml --tags some_tags
 # if use `vagrant ssh` and you get an error related to encoding issues, use:
 # export LC_ALL=C.UTF-8
 ```
@@ -38,7 +38,7 @@ ansible-playbook -i localhost, -c local /vagrant/res/ansible/main.yml --tags som
 
 You need ansible to be installed on the host to do that.
 ```bash
-python3 -m pip install ansible
+python3 -m pip install --break-system-packages ansible
 ```
 
 You can run the playbook with

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,9 +45,9 @@ Vagrant.configure("2") do |config|
     targets&.each do |name, target|
         config.vm.define name do |build|
             build.vm.provider "parallels" do |prl, override|
-                override.vm.box = target["parallels"]["box"]
-                if not target["parallels"]["version"].empty?
-                    override.vm.box_version = target["parallels"]["version"]
+                override.vm.box = target.fetch("parallels", {}).fetch("box")
+                if not target.fetch("parallels", {}).fetch("version", "").empty?
+                    override.vm.box_version = target.fetch("parallels", {}).fetch("version", "")
                 end
                 prl.name = name
 
@@ -70,9 +70,9 @@ Vagrant.configure("2") do |config|
             end
 
             build.vm.provider :virtualbox do |vb, override|
-                override.vm.box = target["virtualbox"]["box"]
-                if not target["virtualbox"]["version"].empty?
-                    override.vm.box_version = target["virtualbox"]["version"]
+                override.vm.box = target.fetch("virtualbox", {})["box"]
+                if not target.fetch("virtualbox", {}).fetch("version", "").empty?
+                    override.vm.box_version = target.fetch("virtualbox", {}).fetch("version", "")
                 end
                 vb.name = name
 
@@ -118,7 +118,7 @@ Vagrant.configure("2") do |config|
             end
 
             # Test if ip is provided
-            if not target["ip"].empty?
+            if not target.fetch("ip", "").empty?
                 build.vm.network "private_network", ip: target["ip"]
             end
 

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,5 +1,5 @@
 targets:
-  sandbox-02:
+  sandbox-01:
     virtualbox:
       box: ubuntu/jammy64
       version: 20230510.0.0

--- a/config/targets.yaml
+++ b/config/targets.yaml
@@ -1,14 +1,14 @@
 targets:
-  sandbox-01:
+  sandbox-02:
     virtualbox:
       box: ubuntu/jammy64
       version: 20230510.0.0
     parallels:
-      box: bento/ubuntu-22.04-arm64
-      version: 202401.31.0
+      box: bento/ubuntu-24.04
+      version: 202407.22.0
     # other ranges could fail?
     # see: https://github.com/hashicorp/vagrant/issues/12557
-    ip: 192.168.56.105
+    ip: 192.168.56.105 # doesn't work on parallels
     cpus: 3
     memory: 4096
     vram: 32

--- a/res/ansible/files/grub.d/disable-ipv6.cfg
+++ b/res/ansible/files/grub.d/disable-ipv6.cfg
@@ -1,0 +1,2 @@
+# https://askubuntu.com/questions/309461/how-to-disable-ipv6-permanently
+GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} ipv6.disable=1"

--- a/res/ansible/files/grub.d/disable-sve.cfg
+++ b/res/ansible/files/grub.d/disable-sve.cfg
@@ -1,0 +1,4 @@
+# there is currently an issue with Apple M4 and macOS 15.2 with java
+# see https://forum.parallels.com/threads/parallels-desktop-for-mac-computers-with-apple-silicon-m4-chips.365676/page-8#post-936240
+# also https://github.com/corretto/corretto-21/issues/85
+GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} arm64.nosve"

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -24,10 +24,19 @@
     tags: 
       - set-vars
 
+  - name: Remove unwanted packages
+    ansible.builtin.apt:
+      pkg:
+        "{{ unwanted }}"
+      state: absent
+      update_cache: yes
+    tags:
+      - remove-unwanted
+
   - name: Update all packages to the latest version
     apt:
       state: latest
-      update_cache: yes
+      update_cache: no
     tags:
       - install-update
 

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -30,13 +30,15 @@
         "{{ unwanted }}"
       state: absent
       update_cache: yes
+      cache_valid_time: 86400
     tags:
       - remove-unwanted
 
   - name: Update all packages to the latest version
     apt:
-      state: latest
-      update_cache: no
+      upgrade: yes
+      update_cache: yes
+      cache_valid_time: 86400
     tags:
       - install-update
 
@@ -45,7 +47,8 @@
       pkg: 
         "{{ packages }}"
       state: latest
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags:
       - install-base-packages
 
@@ -56,7 +59,8 @@
       pkg:
         - docker.io
       state: latest
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags:
       - install-docker
 
@@ -157,7 +161,8 @@
         - python3
         - python3-pip
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-oletools
 
   - name: Olevba - Installation
@@ -171,7 +176,8 @@
       name:
         - poppler-utils
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-pdftools
 
   - name: Pdftools - Cloning pdf github tools
@@ -211,7 +217,8 @@
       name:
         - tesseract-ocr
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-tesseract
 
   - name: Tesseract - install language package
@@ -234,7 +241,8 @@
         - wget
         - unzip
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-ghidra
 
   - name: Ghidra - Set the PATH environment for JAVA
@@ -376,7 +384,8 @@
     ansible.builtin.apt:
       name: brave-browser
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-brave
 
   ## Yara
@@ -385,7 +394,8 @@
     ansible.builtin.apt:
       name: yara
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-yara
 
   - name: Yara - Check if yara_scan exists in .zshrc
@@ -416,7 +426,8 @@
         - clamav
         - clamav-daemon
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-clamav
 
   - name: ClamAV - Disable real time scanning
@@ -425,7 +436,8 @@
         - clamav
         - clamav-daemon
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-clamav
 
   - name: ClamAV - Ensure clamav-daemon is stopped and disabled
@@ -460,7 +472,8 @@
     apt:
       name: code
       state: present
-      update_cache: no
+      update_cache: yes
+      cache_valid_time: 86400
     tags: install-vscode
 
   ## Golang
@@ -552,7 +565,7 @@
 
   - name: ProtonVPN - Download deb
     ansible.builtin.get_url:
-      url: https://repo.protonvpn.com/debian/dists/stable/main/binary-all/protonvpn-stable-release_1.0.3-3_all.deb
+      url: https://repo.protonvpn.com/debian/dists/stable/main/binary-all/protonvpn-stable-release_1.0.6_all.deb
       dest: /tmp/package.deb
       checksum: sha256:de7ef83a663049b5244736d3eabaacec003eb294a4d6024a8fbe0394f22cc4e5
     tags:

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -166,7 +166,12 @@
     tags: install-oletools
 
   - name: Olevba - Installation
-    ansible.builtin.shell: python3 -m pip install --upgrade pip oletools
+    ansible.builtin.pip:
+      name:
+        - oletools
+      state: latest
+      break_system_packages: true
+    become_user: vagrant
     tags: install-oletools
 
   ## pdfid, pdf-parser (DidierStensSuite)
@@ -224,7 +229,7 @@
   - name: Tesseract - install language package
     ansible.builtin.get_url:
       url: "https://github.com/tesseract-ocr/tessdata/raw/4.00/{{ item }}.traineddata"
-      dest: /usr/share/tesseract-ocr/4.00/tessdata/
+      dest: /usr/share/tesseract-ocr/5/tessdata/
     with_items:
       - fra
       - eng
@@ -288,7 +293,7 @@
   - name: Ghidra - Download source
     ansible.builtin.get_url:
       #todo(dfelo): use var for version.
-      url: https://github.com/NationalSecurityAgency/ghidra/archive/refs/tags/Ghidra_11.2_build.zip
+      url: https://github.com/NationalSecurityAgency/ghidra/archive/refs/tags/Ghidra_11.2.1_build.zip
       dest: /tmp/ghidra.zip
     tags: install-ghidra
 
@@ -480,7 +485,7 @@
   #########################################
   - name: Golang - Downloading
     get_url:
-      url: "https://dl.google.com/go/go1.20.5.linux-{{ apt_arch }}.tar.gz"
+      url: "https://dl.google.com/go/go1.23.4.linux-{{ apt_arch }}.tar.gz"
       dest: /tmp/go.tar.gz
       mode: '0755'
     tags: install-golang
@@ -567,7 +572,7 @@
     ansible.builtin.get_url:
       url: https://repo.protonvpn.com/debian/dists/stable/main/binary-all/protonvpn-stable-release_1.0.6_all.deb
       dest: /tmp/package.deb
-      checksum: sha256:de7ef83a663049b5244736d3eabaacec003eb294a4d6024a8fbe0394f22cc4e5
+      checksum: sha256:e5e03976d0980bafdf07da2f71b14fbc883c091e72b16772199742c98473002f
     tags:
       - install-protonvpn
 
@@ -590,11 +595,20 @@
         - pyopenssl
         - cryptography
       state: latest
+      break_system_packages: true
+    become_user: vagrant
     tags:
       - install-protonvpn
 
   - name:
     ansible.builtin.debug:
-      msg: Make sure to REBOOT for protonVPN to work
+      msg: |
+        Reboot for protonvpn to work!
+        For an unknown reason, protonvpn-cli login doesn't work without a proxy.
+        Run the following to login:
+          openssl x509 -inform der -in ~/Desktop/burp.cer -outform PEM -out ~/Desktop/burp.pem
+          sudo cp ~/Desktop/burp.pem /usr/local/share/ca-certificates/burp.pem
+          export http_proxy=http://localhost:8080 && export https_proxy=http://localhost:8080 && export REQUESTS_CA_BUNDLE=/usr/local/share/ca-certificates/burp.pem
+          protonvpn-cli login <username>
     tags:
       - install-protonvpn

--- a/res/ansible/pre-main.yml
+++ b/res/ansible/pre-main.yml
@@ -1,0 +1,22 @@
+- hosts: all
+  gather_facts: yes
+  become: yes
+  handlers:
+    - name: Update GRUB configuration
+      ansible.builtin.command: update-grub
+  tasks:
+    - name: Copy files to /etc/grub.d/
+      copy:
+        src: "{{ item }}"  # Path to the source file on the control node
+        dest: "/etc/default/grub.d/"  # Path to the destination on the target node
+        owner: root
+        group: root
+        mode: 0755
+      with_fileglob:
+        - "files/grub.d/*.cfg"
+      notify:
+        - Update GRUB configuration
+    - name:
+      ansible.builtin.debug:
+        msg: |
+          "Please reboot the system to apply the changes."

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -18,3 +18,14 @@ packages:
   - mpack # used for unpacking eml files.
   # network tools
   - nmap
+unwanted:
+  - apport
+  - apport-symptoms
+  - popularity-contest
+  - ubuntu-report
+  - whoopsie
+  # cloud
+  - cloud-init
+  - cloud-guest-utils
+  - cloud-initramfs-copymods
+  - cloud-initramfs-dyn-netconf

--- a/res/ansible/vars/jammy.yml
+++ b/res/ansible/vars/jammy.yml
@@ -6,7 +6,6 @@ packages:
   - zsh
   - vim-gtk
   - terminator
-  - vim-gtk
   - kmod
   - unzip
   - git

--- a/res/ansible/vars/noble.yml
+++ b/res/ansible/vars/noble.yml
@@ -1,0 +1,31 @@
+packages:
+  # GUI
+  - ubuntu-desktop # this is for gnome4
+  # base tools
+  - zsh
+  - vim-gtk3
+  - terminator
+  - kmod
+  - unzip
+  - git
+  - firefox
+  - chromium-browser
+  # basic forensic tools
+  - libimage-exiftool-perl
+  - binwalk
+  - mpack # used for unpacking eml files.
+  # network tools
+  - nmap
+unwanted:
+  - apport
+  - apport-symptoms
+  - popularity-contest
+  - ubuntu-report
+  - whoopsie
+  # cloud
+  - cloud-init
+  - cloud-guest-utils
+  - cloud-initramfs-copymods
+  - cloud-initramfs-dyn-netconf
+  # misc
+  - qrtr-tools


### PR DESCRIPTION
# Summary

This PR adds many things:
* Upgrade sandbox to 24.04
* Fix issues on Apple M4 and macOS 15.2 with Java. More information [here](https://forum.parallels.com/threads/parallels-desktop-for-mac-computers-with-apple-silicon-m4-chips.365676/page-8#post-936240) or [here](https://github.com/corretto/corretto-21/issues/85)
* Update Vagrantfile to use `.fetch` to avoid unspecified parameters
* Disables ipv6
* Removes unwanted packages such as `whoopsie`, `apport`, ...
* Improves `apt` ansible instructions with caching

There is an issue with `protonvpn-cli` on Ubuntu 24.04 with `python3.12` when we run `protonvpn-cli login`.
It's likely related to incompatibilities with python3.12 and older versions.
I documented a workaround where login works with a proxy (burp here).
